### PR TITLE
adding module to parser options for eslint 2.0.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -31,6 +31,9 @@ module.exports = {
     "templateStrings": true,
     "jsx": true
   },
+  "parserOptions": {
+    "sourceType": "module"
+  },
   "rules": {
     // require parens in arrow function arguments
     "arrow-parens": 2,

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "priceline-eslint-config",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Priceline's eslint file",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
To allow import/export syntax in eslint 2.0.0 you apparently have to add

```
    parserOptions: {
        sourceType: "module"
    }
```

See http://eslint.org/docs/user-guide/migrating-to-2.0.0
