### PR TITLE
feat ( code linting ): Outlaw "comma dangle", make "comma-style": "first"

### DIFF
--- a/babel/index.js
+++ b/babel/index.js
@@ -176,9 +176,9 @@ module.exports = {
     // enforce spacing before and after comma
     "comma-spacing": [2, {"before": false, "after": true}],
     // enforce one true comma style
-    "comma-style": [2, "last"],
+    "comma-style": [2, "first"],
     // enforce use of trailing commas in object and array literals
-    "comma-dangle": [1, "always-multiline"],
+    "comma-dangle": [1, "never"],
     // require or disallow padding inside computed properties
     "computed-property-spacing": 0,
     // enforces consistent naming when capturing the current execution context

--- a/babel/index.js
+++ b/babel/index.js
@@ -176,9 +176,9 @@ module.exports = {
     // enforce spacing before and after comma
     "comma-spacing": [2, {"before": false, "after": true}],
     // enforce one true comma style
-    "comma-style": [2, "first"],
+    "comma-style": [2, "last"],
     // enforce use of trailing commas in object and array literals
-    "comma-dangle": [1, "never"],
+    "comma-dangle": [2, "only-multiline"],
     // require or disallow padding inside computed properties
     "computed-property-spacing": 0,
     // enforces consistent naming when capturing the current execution context

--- a/index.js
+++ b/index.js
@@ -173,9 +173,9 @@ module.exports = {
     // enforce spacing before and after comma
     "comma-spacing": [2, {"before": false, "after": true}],
     // enforce one true comma style
-    "comma-style": [2, "first"],
+    "comma-style": [2, "last"],
     // enforce use of trailing commas in object and array literals
-    "comma-dangle": [1, "never"],
+    "comma-dangle": [2, "only-multiline"],
     // require or disallow padding inside computed properties
     "computed-property-spacing": 0,
     // enforces consistent naming when capturing the current execution context

--- a/index.js
+++ b/index.js
@@ -173,9 +173,9 @@ module.exports = {
     // enforce spacing before and after comma
     "comma-spacing": [2, {"before": false, "after": true}],
     // enforce one true comma style
-    "comma-style": [2, "last"],
+    "comma-style": [2, "first"],
     // enforce use of trailing commas in object and array literals
-    "comma-dangle": [1, "always-multiline"],
+    "comma-dangle": [1, "never"],
     // require or disallow padding inside computed properties
     "computed-property-spacing": 0,
     // enforces consistent naming when capturing the current execution context

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "priceline-eslint-config",
-  "version": "1.2.2",
+  "version": "1.2.3",
   "description": "Priceline's eslint file",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Outlaw the "comma dangle" errors because it's an anti-pattern, switch to first instead of last comma.
